### PR TITLE
Fix card modal attachments scrolling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4929,7 +4929,6 @@ function CardModal(props: {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [panelSize, setPanelSize] = useState<{ w: number; h: number }>({ w: 1120, h: 740 });
-  const [panelHasCustomSize, setPanelHasCustomSize] = useState(false);
   const [panelResizing, setPanelResizing] = useState(false);
   const [panelFullscreen, setPanelFullscreen] = useState(false);
   const panelResizeRef = useRef<{ startX: number; startY: number; startW: number; startH: number } | null>(null);
@@ -5052,7 +5051,6 @@ function CardModal(props: {
           typeof window !== "undefined" ? Math.max(480, window.innerWidth - 48) : Math.max(480, nextW);
         const maxRight = Math.max(CARD_MIN_RIGHT_PX, layoutGuess - CARD_MIN_LEFT_PX - CARD_SPLITTER_COL_PX);
         setRightWidth(clamp(nextRightW, CARD_MIN_RIGHT_PX, maxRight));
-        setPanelHasCustomSize(true);
       }
     } catch {
       // ignore
@@ -5306,7 +5304,6 @@ function CardModal(props: {
       panelResizeRef.current = null;
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
-      setPanelHasCustomSize(true);
       try {
         localStorage.setItem(
           `ioterra.cardModal.size.${props.viewer.id}`,
@@ -5777,7 +5774,6 @@ function CardModal(props: {
             onMouseDown={(e) => {
               panelResizeRef.current = { startX: e.clientX, startY: e.clientY, startW: panelSize.w, startH: panelSize.h };
               setPanelResizing(true);
-              setPanelHasCustomSize(true);
               document.body.style.cursor = "se-resize";
               document.body.style.userSelect = "none";
               e.preventDefault();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5766,9 +5766,7 @@ function CardModal(props: {
           ? { width: "100%", height: "100%", maxHeight: "100%" }
           : {
               width: Math.min(panelSize.w, window.innerWidth - 32),
-              ...(panelHasCustomSize || panelResizing
-                ? { height: Math.min(panelSize.h, window.innerHeight - 32) }
-                : { maxHeight: window.innerHeight - 32 }),
+              height: Math.min(panelSize.h, window.innerHeight - 32),
             }
       }
       panelOverlay={
@@ -6488,7 +6486,7 @@ function CardModal(props: {
               </div>
           </div>
 
-          <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white p-2">
+          <div className="flex min-h-32 shrink-0 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white p-2">
             <div className="mb-1.5 flex shrink-0 items-center justify-between gap-2">
               <div className="text-sm font-semibold text-slate-900">Вложения</div>
               {canEditCard ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Give the card modal an explicit viewport-constrained height so its internal panes can scroll correctly.
- Prevent the attachments section from collapsing under long card details.
- Remove the now-unused modal custom-size flag after the layout change.

## Testing
- `npm run build --workspace frontend` ✅
- `npm run lint --workspace frontend` ⚠️ fails on existing unrelated `frontend/src/App.tsx` lint debt (for example `react-hooks/set-state-in-effect`, `@typescript-eslint/no-explicit-any`, and `react-hooks/refs` outside the touched lines).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da372452-4348-4d5d-9dc6-f96676906e36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da372452-4348-4d5d-9dc6-f96676906e36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

