### PR TITLE
Highlight card importance with background colors

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,14 +68,14 @@ function importanceBadge(importance: Importance) {
   }
 }
 
-function cardBorderClass(importance: Importance) {
+function cardImportanceClass(importance: Importance) {
   switch (importance) {
     case "LOW":
-      return "border-slate-200 hover:border-slate-300";
+      return "border-slate-200 bg-slate-50 hover:border-slate-300 hover:bg-slate-200";
     case "MEDIUM":
-      return "border-[#246c7c] hover:border-[#246c7c]";
+      return "border-[#246c7c] bg-[#e7f4f6] hover:border-[#246c7c] hover:bg-[#d3ebef]";
     case "HIGH":
-      return "border-[#ac4c1c] hover:border-[#ac4c1c]";
+      return "border-[#ac4c1c] bg-[#fff0e8] hover:border-[#ac4c1c] hover:bg-[#ffe0d0]";
   }
 }
 
@@ -334,9 +334,8 @@ function CardTile(props: {
       ref={setRefs}
       style={style}
       className={classNames(
-        "group rounded-xl border-2 bg-white p-3 shadow-sm transition-colors",
-        cardBorderClass(props.card.importance),
-        "hover:bg-slate-200",
+        "group rounded-xl border-2 p-3 shadow-sm transition-colors",
+        cardImportanceClass(props.card.importance),
         isDragging && "opacity-50",
         props.isSelected && "ring-2 ring-[#246c7c] ring-offset-2",
       )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add subtle background colors to kanban cards based on task importance.
- Keep existing importance borders, badges, readable text, and hover highlighting.

Fixes #83

## Walkthrough
[importance_background_hover_demo.mp4](https://cursor.com/agents/bc-929cdca7-573e-4e8e-ba6e-3d7c4a7f629b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fimportance_background_hover_demo.mp4)
[Importance background cards](https://cursor.com/agents/bc-929cdca7-573e-4e8e-ba6e-3d7c4a7f629b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fimportance_background_cards.webp)

## Testing
- Passed: `npm run build -w frontend`
- Passed: `npm run test -w frontend`
- Passed: manual UI verification in Chrome using a temporary mock API because Docker/Postgres are not available in this VM.
- Warning: `npm run lint -w frontend` fails on pre-existing lint errors unrelated to this change.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-929cdca7-573e-4e8e-ba6e-3d7c4a7f629b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-929cdca7-573e-4e8e-ba6e-3d7c4a7f629b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

